### PR TITLE
refactor login button for simplicity, idiomatic interface, and accessibility

### DIFF
--- a/Sources/Views/LoginWithYouVersionButton.swift
+++ b/Sources/Views/LoginWithYouVersionButton.swift
@@ -8,28 +8,27 @@ public struct LoginWithYouVersionButton: View {
         case iconOnly
     }
 
-    public enum Shape {
-        case button
+    public enum ButtonShape {
+        case capsule
         case rectangle
     }
     
     @Environment(\.colorScheme) var colorScheme
-    @State private var shape: Shape = .button
-    @State private var mode: Mode = .full
-    @State private var stroked = true
+    private let shape: ButtonShape
+    private let mode: Mode
+    private let isStroked: Bool
     private let verticalPadding = CGFloat(12)
     private let horizontalPadding = CGFloat(20)
-    private let strokeWidth = CGFloat(1.5)
-    @ScaledMetric(relativeTo: .body) private var iconSize: CGFloat = 24
-    let onTap: () -> Void
+    private let onTap: () -> Void
+    @ScaledMetric(relativeTo: .body) private var iconEdge: CGFloat = 24
     
-    public init(shape: Shape = .button,
+    public init(shape: ButtonShape = .capsule,
                 mode: Mode = .full,
-                stroked: Bool = true,
+                isStroked: Bool = true,
                 onTap: @escaping () -> Void) {
         self.shape = shape
         self.mode = mode
-        self.stroked = stroked
+        self.isStroked = isStroked
         self.onTap = onTap
     }
     
@@ -43,19 +42,12 @@ public struct LoginWithYouVersionButton: View {
 #if SWIFT_PACKAGE
         return Image("BibleAppLogo@4x", bundle: .module)
             .resizable()
-            .frame(width: iconSize, height: iconSize)
+            .frame(width: iconEdge, height: iconEdge)
 #else
         return Image("BibleAppLogo@4x")
             .resizable()
-            .frame(width: iconSize, height: iconSize)
+            .frame(width: iconEdge, height: iconEdge)
 #endif
-    }
-    
-    func cornerRadius(_ shape: Shape? = nil) -> CGFloat {
-        switch shape ?? self.shape {
-        case .button: 40
-        case .rectangle: 4
-        }
     }
     
     private var localizedLoginText: Text {
@@ -73,98 +65,108 @@ public struct LoginWithYouVersionButton: View {
         return Text(attributed)
     }
     
-    private func textOrEmpty(_ txt: String) -> Text {
-        txt.isEmpty ? Text("") : Text(txt)
+    private var strokeWidth: CGFloat {
+        isStroked ? 1.5 : 0
+    }
+    
+    @ViewBuilder
+    private var buttonContent: some View {
+        switch mode {
+        case .iconOnly:
+            bibleAppLogo
+                .padding(verticalPadding)
+        case .full:
+            HStack(spacing: 0) {
+                bibleAppLogo
+                    .padding(.trailing, 8)
+                localizedLoginText
+            }
+            .padding(.vertical, verticalPadding)
+            .padding(.horizontal, horizontalPadding)
+        case .compact:
+            HStack(spacing: 0) {
+                bibleAppLogo
+                    .padding(.trailing, 8)
+                Text("Sign in")
+            }
+            .padding(.vertical, verticalPadding)
+            .padding(.horizontal, horizontalPadding)
+        }
     }
     
     public var body: some View {
         Button(action: onTap) {
-            switch mode {
-            case .iconOnly:
-                HStack(spacing: 0) {
-                    bibleAppLogo
-                        .padding(verticalPadding)  // it's deliberate that we're not using horizontalPadding here
-                        .foregroundColor(colorScheme == .dark ? .white : .black)
-                        .background(colorScheme == .dark ? Color.black : Color.white)
-                        .cornerRadius(cornerRadius(.rectangle))
-                        .clipShape(RoundedRectangle(cornerRadius: cornerRadius()))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: cornerRadius())
-                                .stroke(strokeColor, lineWidth: stroked ? strokeWidth : 0)
-                        )
-                }
-            case .full:
-                HStack(spacing: 0) {
-                    bibleAppLogo
-                        .padding(.trailing, 8)
-                    localizedLoginText
-                }
-                .padding(.vertical, verticalPadding)
-                .padding(.horizontal, horizontalPadding)
-                .foregroundColor(colorScheme == .dark ? .white : .black)
-                .background(colorScheme == .dark ? Color.black : Color.white)
-                .cornerRadius(cornerRadius())
-                .clipShape(RoundedRectangle(cornerRadius: cornerRadius()))
+            buttonContent
+                .accessibilityLabel(Text("Sign in with YouVersion"))
+                .accessibilityAddTraits(.isButton)
+        }
+        .buttonStyle(
+            LoginWithYouVersionButtonStyle(
+                shape: shape,
+                strokeColor: strokeColor,
+                strokeWidth: strokeWidth,
+                colorScheme: colorScheme
+            )
+        )
+    }
+}
+
+private struct LoginWithYouVersionButtonStyle: ButtonStyle {
+    let shape: LoginWithYouVersionButton.ButtonShape
+    let strokeColor: Color
+    let strokeWidth: CGFloat
+    let colorScheme: ColorScheme
+
+    func makeBody(configuration: Configuration) -> some View {
+        let content = configuration.label
+            .foregroundColor(colorScheme == .dark ? Color.white : Color.black)
+            .background(colorScheme == .dark ? Color.black : Color.white)
+            .opacity(configuration.isPressed ? 0.8 : 1.0)
+
+        if shape == .capsule {
+            content
+                .clipShape(Capsule())
                 .overlay(
-                    RoundedRectangle(cornerRadius: cornerRadius())
-                        .stroke(strokeColor, lineWidth: stroked ? strokeWidth : 0)
+                    Capsule()
+                        .stroke(strokeColor, lineWidth: strokeWidth)
                 )
-            case .compact:
-                HStack(spacing: 0) {
-                    bibleAppLogo
-                        .padding(.trailing, 8)
-                    Text("Sign in")
-                }
-                .padding(.vertical, verticalPadding)
-                .padding(.horizontal, horizontalPadding)
-                .foregroundColor(colorScheme == .dark ? .white : .black)
-                .background(colorScheme == .dark ? Color.black : Color.white)
-                .cornerRadius(cornerRadius())
-                .clipShape(RoundedRectangle(cornerRadius: cornerRadius()))
+        } else {
+            content
+                .clipShape(RoundedRectangle(cornerRadius: 4))
                 .overlay(
-                    RoundedRectangle(cornerRadius: cornerRadius())
-                        .stroke(strokeColor, lineWidth: stroked ? strokeWidth : 0)
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(strokeColor, lineWidth: strokeWidth)
                 )
-            }
         }
     }
 }
 
-struct LoginWithYouVersionButton_Previews: PreviewProvider {
-    
-    static var previews: some View {
-        Group {
-            VStack {
-                buttonGrid
-                    .environment(\.colorScheme, .light)
-                buttonGrid
-                    .environment(\.colorScheme, .dark)
-            }
-            .padding()
-            .background(content: { Color.green })
+#Preview {
+    buttonGrid
+        .padding()
+        .background(Color.green)
+}
+
+#if DEBUG
+@MainActor
+private var buttonGrid: some View {
+    VStack {
+        LoginWithYouVersionButton(mode: .full, isStroked: true, onTap: {})
+        LoginWithYouVersionButton(mode: .full, isStroked: false, onTap: {})
+        HStack {
+            LoginWithYouVersionButton(mode: .compact, isStroked: true, onTap: {})
+            LoginWithYouVersionButton(mode: .compact, isStroked: false, onTap: {})
         }
-    }
-    
-    static var buttonGrid: some View {
-        VStack {
-            VStack {
-                LoginWithYouVersionButton(mode: .full, stroked: true, onTap: {})
-                LoginWithYouVersionButton(mode: .full, stroked: false, onTap: {})
-                HStack {
-                    LoginWithYouVersionButton(mode: .compact, stroked: true, onTap: {})
-                    LoginWithYouVersionButton(mode: .compact, stroked: false, onTap: {})
-                }
-                LoginWithYouVersionButton(shape: .rectangle, mode: .full, stroked: true, onTap: {})
-                LoginWithYouVersionButton(shape: .rectangle, mode: .full, stroked: false, onTap: {})
-                HStack {
-                    LoginWithYouVersionButton(shape: .rectangle, mode: .compact, stroked: true, onTap: {})
-                    LoginWithYouVersionButton(shape: .rectangle, mode: .compact, stroked: false, onTap: {})
-                }
-                HStack {
-                    LoginWithYouVersionButton(shape: .rectangle, mode: .iconOnly, stroked: true, onTap: {})
-                    LoginWithYouVersionButton(shape: .rectangle, mode: .iconOnly, stroked: false, onTap: {})
-                }
-            }
+        LoginWithYouVersionButton(shape: .rectangle, mode: .full, isStroked: true, onTap: {})
+        LoginWithYouVersionButton(shape: .rectangle, mode: .full, isStroked: false, onTap: {})
+        HStack {
+            LoginWithYouVersionButton(shape: .rectangle, mode: .compact, isStroked: true, onTap: {})
+            LoginWithYouVersionButton(shape: .rectangle, mode: .compact, isStroked: false, onTap: {})
+        }
+        HStack {
+            LoginWithYouVersionButton(shape: .rectangle, mode: .iconOnly, isStroked: true, onTap: {})
+            LoginWithYouVersionButton(shape: .rectangle, mode: .iconOnly, isStroked: false, onTap: {})
         }
     }
 }
+#endif


### PR DESCRIPTION
Improvements for the login button.

Using Xcode's method for displaying light and dark variants:
![yvp-swift-sdk_—_LoginWithYouVersionButton_swift](https://github.com/user-attachments/assets/631894b7-3808-4cbf-bcd7-b641ce09122b)

Fixes issue with button shape at large font sizes:
![yvp-swift-sdk_—_LoginWithYouVersionButton_swift](https://github.com/user-attachments/assets/f0663719-bb99-468d-9ead-c291fae3e43b)
